### PR TITLE
Update class.edd-xero.php : line_amount_type

### DIFF
--- a/class.edd-xero.php
+++ b/class.edd-xero.php
@@ -239,10 +239,11 @@ final class Plugify_EDD_Xero {
 				'id' => 'line_amount_type',
 				'name' => __( 'Line Amount Type', 'edd-xero' ),
 				'type' => 'select',
-				'desc' => __( 'Send invoice line item amount as inclusive or exclusive of tax', 'edd-xero' ),
+				'desc' => __( 'Send invoice line item amount as Exclusive, Inclusive or No Tax', 'edd-xero' ),
 				'options' => array(
 					'Exclusive' => 'Exclusive',
-					'Inclusive' => 'Inclusive'
+					'Inclusive' => 'Inclusive',
+					'NoTax' => 'No Tax'
 				)
 			),
 			'sales_account' => array(


### PR DESCRIPTION
Xero has three options for line amount tax status : Exclusive, Inclusive and No Tax. The No Tax option is essential for micro-enterprises that are not tax registered. Option added in line 246 and description updated in line 242.